### PR TITLE
Improve import_project docs.  JIRA: CXX-3638.

### DIFF
--- a/pages/ch_faq.md
+++ b/pages/ch_faq.md
@@ -43,6 +43,8 @@ This chapter contains frequently asked questions and useful links.
 
         -   [How can I disable the XML declaration or DOCTYPE with the serial library?](#ch_faq.How_can_I_disable_the_XML_declara)
 
+	    -   [How can I import just one project from the source tree (a library), add a sibling application project that will depend on that library project, and have the ability to build both from the common parent node?](#ch_faq.How_can_I_import_just_one_project)
+
     -   [Compiling](#ch_faq.Compiling)
 
         -   [How do I compile for 32-bit on a 64-bit machine in a typical C++ Toolkit app?](#ch_faq.How_do_I_compile_for_32bit_on_a_6)
@@ -240,6 +242,20 @@ Here's a code snippet that shows all combinations:
 ***Note:*** The serial library can read XML whether or not it contains the XML declaration or DOCTYPE without using special flags. For example:
 
     istr >> MSerial_Xml >> obj;
+
+<a name="ch_faq.How_can_I_import_just_one_project"></a>
+
+#### How can I import just one project from the source tree (a library), add a sibling application project that will depend on that library project, and have the ability to build both from the common parent node?
+
+If the application is already present in the C++ Toolkit, just in the `internal` subtree whereas the library is public, you can import the library via [`import_project -topdir trunk/internal/c++ ...`](ch_proj#ch_proj.work_sub_tree) so that both projects will wind up in a single tree, then import the application normally, and finally run
+
+    import_project -topdir trunk/internal/c++ -nocheckout .
+
+to produce a `Makefile.flat` covering both projects.
+
+You can use a similar approach if there's no public/internal mismatch, just without `-topdir`.
+
+If the application is entirely absent from the C++ Toolkit, you can place its code alongside the library along with a suitable [`Makefile.*.app`](ch_proj#ch_proj.make_proj_app), list it in [`Makefile.in`](ch_proj#ch_proj.meta_makefiles), and rerun `import_project` with the `-nocheckout` flag to (re)generate appropriate wrapper makefiles.
 
 <a name="ch_faq.Compiling"></a>
 

--- a/pages/ch_proj.md
+++ b/pages/ch_proj.md
@@ -669,10 +669,10 @@ where:
 
 -   **`builddir`** (optional) specifies what version of the pre-built NCBI C++ Toolkit libraries to link to.
 
-As a result of executing this shell script, you will have a new directory created with the pathname `./[internal/]c++/` whose structure contains "slices" of the original SVN tree. Specifically, you will find:
+As a result of executing this shell script, you will have a new directory created with the pathname `trunk/[internal/]c++/` whose structure contains "slices" of the original SVN tree. Specifically, you will find:
 
-    ./[internal/]c++/include/subtree_name
-    ./[internal/]c++/src/subtree_name
+    trunk/[internal/]c++/include/subtree_name
+    trunk/[internal/]c++/src/subtree_name
 
 The `src` and `include` directories will contain all of the requested subtree's source and header files along with any hierarchically defined subdirectories. In addition, the script will create new makefiles with the suffix *\*\_app*. These makefiles are generated from the original [customized makefiles](#ch_proj.make_proj_app) (`Makefile.*.app`) located in the original `src` subtrees. The customized makefiles were designed to work only in conjunction with the build directories in the larger NCBI C++ tree; the newly created makefiles can be used directly in your new working directories.
 
@@ -682,13 +682,12 @@ You can re-run **import\_project** to add multiple projects to your tree.
 
     import_project internal/demo/misc/xmlwrapp
     import_project -topdir trunk/internal/c++ misc/xmlwrapp
-    pushd trunk/internal/c++/src/misc/xmlwrapp
-    make
+	import_project -topdir trunk/internal/c++ -nocheckout .
+	pushd trunk/internal/c++/src
+    make -f Makefile.flat
     popd
-    pushd trunk/internal/c++/src/internal/demo/misc/xmlwrapp
-    make
 
-In this case, your public projects will be located in the `internal` tree. You must build in each imported subtree, in order from most-dependent to least-dependent so that the imported libraries will be linked to rather than the pre-built libraries.
+The third `import_project` command in this example produces a unified `Makefile.flat` covering both subtrees.  Without this command, it would be necessary to build them individually, starting with the libraries, so that the demos would link to imported rather than prebuilt libraries.
 
 The NCBI C++ Toolkit project directories, along with the libraries they implement and the logical modules they entail, are summarized in the [Library Reference](part3.html).
 


### PR DESCRIPTION
* pages/ch_faq.md: Explain how to build applications against imported
  libraries when the applications don't share the libraries' subtree,
  and might not (yet) exist in the C++ Toolkit at all.
* pages/ch_proj.md: Correctly state that import_project populates
  trunk/c++ or trunk/internal/c++, as already shown in the example;
  when it is necessary to import several subtrees, recommend one final
  import_project -nocheckout run to produce a unified Makefile.flat.